### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://amitkumariiith.visualstudio.com/373f890b-d61b-4850-bbf2-9d5dd4349791/8e1142a6-10f3-473c-8868-7b8b5cabab1b/_apis/work/boardbadge/5a986c5a-7548-4118-8c40-543d8ca4c253)](https://amitkumariiith.visualstudio.com/373f890b-d61b-4850-bbf2-9d5dd4349791/_boards/board/t/8e1142a6-10f3-473c-8868-7b8b5cabab1b/Microsoft.RequirementCategory)
 # testrepo
 this is a test repo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#50. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.